### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -525,6 +525,7 @@ Powered by <span style="color:${accentColor};font-weight:600;">NovaBilling</span
     return html
       .replace(/<[^>]*>/g, '')
       .replace(/\s+/g, ' ')
+      .replace(/[<>]/g, '')
       .trim();
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/novabilling/billing/security/code-scanning/8](https://github.com/novabilling/billing/security/code-scanning/8)

In general, to fix incomplete multi‑character sanitization for HTML/script concerns, you should either (a) use a well‑tested HTML sanitization/stripping library, or (b) implement a robust strategy that ensures unsafe characters (`<`, `>`, `&`, etc.) cannot reappear after a single pass. For producing plain‑text from HTML, the most reliable approach is to parse the HTML and extract text content, or at minimum to strip tags and then neutralize any remaining angle brackets.

Here, `stripHtml` is trying to produce a plain‑text representation of `html`. The simplest robust change that does not alter existing semantics too much is:

1. Keep the current tag‑stripping and whitespace‑collapsing behavior to preserve existing output as much as possible.
2. After that, explicitly remove or escape all remaining `<` and `>` characters so that no `<script` or other tags can be interpreted if the string is ever placed back into HTML.
3. Optionally, also normalize `&` entities to avoid partially decoded HTML, but CodeQL’s specific concern is with `<script`.

A minimal, targeted fix inside `backend/src/services/email.service.ts` is:

- Modify `stripHtml` to add a final `.replace(/[<>]/g, '')` step after the existing processing. This ensures that even if the regex removal of `<[^>]*>` is incomplete or a second‑order `../`‑style issue appears, no `<` remains to start a tag (including `<script`).

Concretely:

- In `backend/src/services/email.service.ts`, at lines 524–528, extend the method chain in `stripHtml` to add `.replace(/[<>]/g, '')` before `.trim()` (or just before `.trim()` so whitespace trimming is still last).

No new imports or helper methods are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
